### PR TITLE
Typo fix for Ad Product 1293 'Weightloss Services'

### DIFF
--- a/Ad Product Taxonomies/Ad Product Taxonomy 2.0.tsv
+++ b/Ad Product Taxonomies/Ad Product Taxonomy 2.0.tsv
@@ -292,7 +292,7 @@ Unique ID	Parent ID	Name	Tier 1	Tier 2	Tier 3
 1290	1263	Luggage and Bags	Durable Goods	Luggage and Bags	
 1291		Dieting and Weightloss	Dieting and Weightloss		
 1292	1291	Food Logging	Dieting and Weightloss	Food Logging	
-1293	1291	Weightloss Servies	Dieting and Weightloss	Weightloss Servies	
+1293	1291	Weightloss Services	Dieting and Weightloss	Weightloss Services	
 1294	1291	Workout and Step Tracking Applications	Dieting and Weightloss	Workout and Step Tracking Applications	
 1295		Education and Careers	Education and Careers		
 1296	1295	Adult Education	Education and Careers	Adult Education	


### PR DESCRIPTION
In the current main branch the Ad Product Category 1293 in Version 2.0 of the Taxonomy is labelled 'Weightloss Servies'
I have just changed the two references to fix this typo so it reads: 'Weightloss Services'



























