### PR TITLE
Error fixes in IAB Content Taxonomy 3.1

### DIFF
--- a/Content Taxonomies/Content Taxonomy 3.1.tsv
+++ b/Content Taxonomies/Content Taxonomy 3.1.tsv
@@ -162,6 +162,39 @@ Unique ID	Parent	Name	Tier 1	Tier 2	Tier 3	Tier 4
 JLBCU7		Entertainment	Entertainment				
 324	JLBCU7	Movies	Entertainment	Movies			
 338	JLBCU7	Music	Entertainment	Music			
+342	338	Adult Album Alternative	Entertainment	Music	Adult Album Alternative		
+339	338	Adult Contemporary Music	Entertainment	Music	Adult Contemporary Music		
+340	339	Soft AC Music	Entertainment	Music	Adult Contemporary Music	Soft AC Music	
+341	339	Urban AC Music	Entertainment	Music	Adult Contemporary Music	Urban AC Music	
+343	338	Alternative Music	Entertainment	Music	Alternative Music		
+360	338	Blues	Entertainment	Music	Blues		
+344	338	Children's Music	Entertainment	Music	Children's Music		
+345	338	Classic Hits	Entertainment	Music	Classic Hits		
+346	338	Classical Music	Entertainment	Music	Classical Music		
+347	338	College Radio	Entertainment	Music	College Radio		
+348	338	Comedy (Music and Audio)	Entertainment	Music	Comedy (Music and Audio)		
+349	338	Contemporary Hits/Pop/Top 40	Entertainment	Music	Contemporary Hits/Pop/Top 40		
+350	338	Country Music	Entertainment	Music	Country Music		
+351	338	Dance and Electronic Music	Entertainment	Music	Dance and Electronic Music		
+354	338	Gospel Music	Entertainment	Music	Gospel Music		
+355	338	Hip Hop Music	Entertainment	Music	Hip Hop Music		
+356	338	Inspirational/New Age Music	Entertainment	Music	Inspirational/New Age Music		
+357	338	Jazz	Entertainment	Music	Jazz		
+358	338	Oldies/Adult Standards	Entertainment	Music	Oldies/Adult Standards		
+362	338	R&B/Soul/Funk	Entertainment	Music	R&B/Soul/Funk		
+359	338	Reggae	Entertainment	Music	Reggae		
+361	338	Religious (Music and Audio)	Entertainment	Music	Religious (Music and Audio)		
+363	338	Rock Music	Entertainment	Music	Rock Music		
+364	363	Album-oriented Rock	Entertainment	Music	Rock Music	Album-oriented Rock	
+365	363	Alternative Rock	Entertainment	Music	Rock Music	Alternative Rock	
+366	363	Classic Rock	Entertainment	Music	Rock Music	Classic Rock	
+367	363	Hard Rock	Entertainment	Music	Rock Music	Hard Rock	
+368	363	Soft Rock	Entertainment	Music	Rock Music	Soft Rock	
+353	338	Songwriters/Folk	Entertainment	Music	Songwriters/Folk		
+369	338	Soundtracks, TV and Showtunes	Entertainment	Music	Soundtracks, TV and Showtunes		
+352	338	World/International Music	Entertainment	Music	World/International Music		
+377	338	Urban Contemporary Music	Entertainment	Music	Urban Contemporary Music		
+378	338	Variety (Music and Audio)	Entertainment	Music	Variety (Music and Audio)		
 640	JLBCU7	Television	Entertainment	Television			
 8VZQHL		Events	Events				
 162	8VZQHL	Awards Shows	Events	Awards Shows			
@@ -229,7 +262,7 @@ TIFQA5	SPSHQ5	Lifestyle	Genres	Lifestyle
 643	SPSHQ5	Special Interest (Indie/Art House)	Genres	Special Interest (Indie/Art House)			
 370	SPSHQ5	Sports Radio	Genres	Sports Radio			
 371	SPSHQ5	Talk Radio	Genres	Talk Radio			
-376	SPSHQ5	Public Radio	Genres	Talk Radio	Public Radio		
+376	371	Public Radio	Genres	Talk Radio	Public Radio		
 A0AH3G	SPSHQ5	Talk Show	Genres	Talk Show			
 KHPC5A	SPSHQ5	True Crime	Genres	True Crime			
 KHPC6A	SPSHQ5	Western	Genres	Western			SCD
@@ -339,39 +372,6 @@ KHPC6A	SPSHQ5	Western	Genres	Western			SCD
 320	286	Pharmaceutical Drugs	Medical Health	Pharmaceutical Drugs			
 321	286	Surgery	Medical Health	Surgery			
 322	286	Vaccines	Medical Health	Vaccines			
-342	338	Adult Album Alternative	Entertainment	Adult Album Alternative			
-339	338	Adult Contemporary Music	Entertainment	Adult Contemporary Music			
-340	339	Soft AC Music	Entertainment	Adult Contemporary Music	Soft AC Music		
-341	339	Urban AC Music	Entertainment	Adult Contemporary Music	Urban AC Music		
-343	338	Alternative Music	Entertainment	Alternative Music			
-360	338	Blues	Entertainment	Blues			
-344	338	Children's Music	Entertainment	Children's Music			
-345	338	Classic Hits	Entertainment	Classic Hits			
-346	338	Classical Music	Entertainment	Classical Music			
-347	338	College Radio	Entertainment	College Radio			
-348	338	Comedy (Music and Audio)	Entertainment	Comedy (Music and Audio)			
-349	338	Contemporary Hits/Pop/Top 40	Entertainment	Contemporary Hits/Pop/Top 40			
-350	338	Country Music	Entertainment	Country Music			
-351	338	Dance and Electronic Music	Entertainment	Dance and Electronic Music			
-354	338	Gospel Music	Entertainment	Gospel Music			
-355	338	Hip Hop Music	Entertainment	Hip Hop Music			
-356	338	Inspirational/New Age Music	Entertainment	Inspirational/New Age Music			
-357	338	Jazz	Entertainment	Jazz			
-358	338	Oldies/Adult Standards	Entertainment	Oldies/Adult Standards			
-362	338	R&B/Soul/Funk	Entertainment	R&B/Soul/Funk			
-359	338	Reggae	Entertainment	Reggae			
-361	338	Religious (Music and Audio)	Entertainment	Religious (Music and Audio)			
-363	338	Rock Music	Entertainment	Rock Music			
-364	363	Album-oriented Rock	Entertainment	Rock Music	Album-oriented Rock		
-365	363	Alternative Rock	Entertainment	Rock Music	Alternative Rock		
-366	363	Classic Rock	Entertainment	Rock Music	Classic Rock		
-367	363	Hard Rock	Entertainment	Rock Music	Hard Rock		
-368	363	Soft Rock	Entertainment	Rock Music	Soft Rock		
-353	338	Songwriters/Folk	Entertainment	Songwriters/Folk			
-369	338	Soundtracks, TV and Showtunes	Entertainment	Soundtracks, TV and Showtunes			
-352	338	World/International Music	Entertainment	World/International Music			
-377	338	Urban Contemporary Music	Entertainment	Urban Contemporary Music			
-378	338	Variety (Music and Audio)	Entertainment	Variety (Music and Audio)			
 163		Personal Celebrations & Life Events	Personal Celebrations & Life Events				
 164	163	Anniversary	Personal Celebrations & Life Events	Anniversary			
 166	163	Baby Shower	Personal Celebrations & Life Events	Baby Shower			
@@ -437,7 +437,6 @@ KHPC6A	SPSHQ5	Western	Genres	Western			SCD
 438	432	Celebrity Scandal	Pop Culture	Celebrity Scandal			
 439	432	Celebrity Style	Pop Culture	Celebrity Style			
 440	432	Humor and Satire	Pop Culture	Humor and Satire			
-W3CW2J	602	Productivity	Technology & Computing	Computing	Computer Software and Applications	Productivity	
 441		Real Estate	Real Estate				
 442	441	Apartments	Real Estate	Apartments			
 445	441	Developmental Sites	Real Estate	Developmental Sites			
@@ -621,10 +620,11 @@ mm3UXx	v9i3On	Online Piracy	Sensitive Topics	Online Piracy
 611	602	Databases	Technology & Computing	Computing	Computer Software and Applications	Databases	
 612	602	Desktop Publishing	Technology & Computing	Computing	Computer Software and Applications	Desktop Publishing	
 613	602	Digital Audio	Technology & Computing	Computing	Computer Software and Applications	Digital Audio	
-WQC6HR	602	Maps & Navigation	Technology & Computing	Computing	Computer Software and Applications	Maps & Navigation	
 614	602	Graphics Software	Technology & Computing	Computing	Computer Software and Applications	Graphics Software	
+WQC6HR	602	Maps & Navigation	Technology & Computing	Computing	Computer Software and Applications	Maps & Navigation	
 615	602	Operating Systems	Technology & Computing	Computing	Computer Software and Applications	Operating Systems	
 604	602	Photo Editing Software	Technology & Computing	Computing	Computer Software and Applications	Photo Editing Software	
+W3CW2J	602	Productivity	Technology & Computing	Computing	Computer Software and Applications	Productivity	
 605	602	Shareware and Freeware	Technology & Computing	Computing	Computer Software and Applications	Shareware and Freeware	
 606	602	Video Software	Technology & Computing	Computing	Computer Software and Applications	Video Software	
 607	602	Web Conferencing	Technology & Computing	Computing	Computer Software and Applications	Web Conferencing	


### PR DESCRIPTION
* Addition of Music as a Tier 2 for all those with a Parent ID of 338, 339 and 363, as well as the move of these to their location in Entertainment.
* Move Productivity and Maps and Navigation to their respective places under Computer Software and Applications.
* Fixed Parent ID of Public Radio to have the Unique ID of Talk Radio instead of Genres